### PR TITLE
parse options, added -i, --ignore-memory

### DIFF
--- a/deploy_caasp.sh
+++ b/deploy_caasp.sh
@@ -1,17 +1,57 @@
 . caasp_env.conf
 
-# Check memory configuration with host
-MASTERMEM=$(sed -n '1,/caasp4-master-/d;/end/,$d;s/lv\.memory = "\([0-9]*\).*/\1/p' Vagrantfile)
-WORKERMEM=$(sed -n '1,/caasp4-worker-/d;/end/,$d;s/lv\.memory = "\([0-9]*\).*/\1/p' Vagrantfile)
-LBMEM=$(sed -n '1,/caasp4-lb-/d;/end/,$d;s/lv\.memory = "\([0-9]*\).*/\1/p' Vagrantfile)
-STORAGEMEM=$(sed -n '1,/caasp4-storage-/d;/end/,$d;s/lv\.memory = "\([0-9]*\).*/\1/p' Vagrantfile)
-MEMNEEDED="$(($MASTERMEM * $NMASTERS + $WORKERMEM * $NWORKERS + $LBMEM * $NLOADBAL + $STORAGEMEM * $NSTORAGE))"
-MEMHOST="$(free -m | awk 'NR==2{print $7}')"
-if [[ "$MEMNEEDED" -gt "$MEMHOST" ]]; then
-    read -r -p "The configuration needs ${MEMNEEDED}MB but the host only has ${MEMHOST}MB available, do you want to continue [y/N] " response
-    response=${response,,}
-    if [[ ! "$response" =~ ^(yes|y)$ ]]; then
-        exit 1
+function printHelp {
+cat << EOF
+Usage ${0##*/} [options..]
+-f, --full           attempt to bring the machines up and deploy the cluster
+-i, --ignore-memory  Don't prompt when over allocating memory
+-h,-?, --help        Show help
+EOF
+}
+
+#initialize all the options
+FULL_DEPLOYMENT=false
+DO_MEMORY_CHECK=true
+while :; do
+    case $1 in
+        -h|-\?|--help)
+            printHelp
+            exit
+            ;;
+        -f|--full)
+            FULL_DEPLOYMENT=true
+            ;;
+        -i|--ignore-memory)
+            DO_MEMORY_CHECK=false
+            ;;
+        --)                 #End of all options
+            shift
+            break
+            ;;
+        -?*)
+            printf "'$1' is not a valid option\n" >&2
+            exit 1
+            ;;
+        *)                 #Break out of case, no more options
+            break
+    esac
+    shift
+done
+
+if [[  $DO_MEMORY_CHECK == true ]]; then
+    # Check memory configuration with host
+    MASTERMEM=$(sed -n '1,/caasp4-master-/d;/end/,$d;s/lv\.memory = "\([0-9]*\).*/\1/p' Vagrantfile)
+    WORKERMEM=$(sed -n '1,/caasp4-worker-/d;/end/,$d;s/lv\.memory = "\([0-9]*\).*/\1/p' Vagrantfile)
+    LBMEM=$(sed -n '1,/caasp4-lb-/d;/end/,$d;s/lv\.memory = "\([0-9]*\).*/\1/p' Vagrantfile)
+    STORAGEMEM=$(sed -n '1,/caasp4-storage-/d;/end/,$d;s/lv\.memory = "\([0-9]*\).*/\1/p' Vagrantfile)
+    MEMNEEDED="$(($MASTERMEM * $NMASTERS + $WORKERMEM * $NWORKERS + $LBMEM * $NLOADBAL + $STORAGEMEM * $NSTORAGE))"
+    MEMHOST="$(free -m | awk 'NR==2{print $7}')"
+    if [[ "$MEMNEEDED" -gt "$MEMHOST" ]]; then
+        read -r -p "The configuration needs ${MEMNEEDED}MB but the host only has ${MEMHOST}MB available, do you want to continue [y/N] " response
+        response=${response,,}
+        if [[ ! "$response" =~ ^(yes|y)$ ]]; then
+            exit 1
+        fi
     fi
 fi
 
@@ -39,7 +79,7 @@ do
     vagrant up caasp4-storage-${s}
 done
 
-if [ "${1}" == "--full" ]; then
+if [[ $FULL_DEPLOYMENT == true ]]; then
     vagrant ssh caasp4-master-1 -c 'sudo su - sles -c /vagrant/deploy/99.run-all.sh'
 fi
 


### PR DESCRIPTION
A suggestion on option parsing, also added the -i, --ignore-memory option so that you could unattended scripted installed when over committing memory usage 