### PR TITLE
Cluster tool

### DIFF
--- a/cluster.sh
+++ b/cluster.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+source caasp_env.conf
+
+function printHelp {
+cat << EOF
+Usage ${0##*/} [options..] [command]
+-v, --verbose        Make the operation more talkative
+-h,-?, --help        Show help and exit
+
+start                start a previosly provisioned cluster
+stop                 stop a running cluster
+
+getToken             get Dashboard token
+EOF
+}
+
+#initialize all the options
+VERBOSE=/bin/false
+while :; do
+    case $1 in
+        -h|-\?|--help)
+            printHelp
+            exit
+            ;;
+        -v|--verbose)
+            VERBOSE=/bin/true
+            ;;
+        --)                 #End of all options
+            shift
+            break
+            ;;
+        -?*)
+            printf "'$1' is not a valid option\n" >&2
+            exit 1
+            ;;
+        *)                 #Break out of case, no more options
+            break
+    esac
+    shift
+done
+
+function start_cluster {
+	$VERBOSE && set -x
+    # start loadbalancers
+    printf "Starting loadbalancers:\n"
+    for NUM in $(seq 1 $NLOADBAL); do
+        vagrant reload caasp4-lb-${NUM}
+    done
+    printf "\n"
+    
+    # Starting storage
+    printf "Starting storage:\n"
+    for NUM in $(seq 1 $NSTORAGE); do
+        vagrant reload caasp4-storage-${NUM}
+    done
+    printf "\n"
+    
+    printf "Staring master nodes\n"
+    for NUM in $(seq 1 $NMASTERS); do
+        vagrant reload caasp4-master-${NUM}
+    done
+    
+    #Waiting for masters to become ready
+    vagrant ssh caasp4-master-1 -c 'sudo -H -u sles bash -c "source /vagrant/utils.sh; wait_for_masters_ready"'
+    
+    printf "Staring worker nodes\n"
+    for NUM in $(seq 1 $NWORKERS); do
+        vagrant reload caasp4-worker-${NUM}
+    done
+    
+    # Waiting for workers to become ready
+    vagrant ssh caasp4-master-1 -c 'sudo -H -u sles bash -c "source /vagrant/utils.sh; wait_for_workers_ready"'
+    
+    printf "Starting scheduling on nodes.\n"
+    vagrant ssh caasp4-master-1 -c 'sudo -H -u sles kubectl get nodes -o name | \
+      sudo -H -u sles xargs -I{} kubectl uncordon {}'
+    
+    printf "Cluster is up and running.....\n"
+	$VERBOSE && set +x
+
+}
+
+function stop_cluster {
+	$VERBOSE && set -x
+    # Disable scheduling on the whole cluster. 
+    # This will avoid Kubernetes rescheduling jobs while you are shutting down nodes
+    printf "Disabling scheduling on cluster nodes:\n"
+    vagrant ssh caasp4-master-1 -c 'sudo -H -u sles kubectl get nodes -o name | \
+      sudo -H -u sles xargs -I{} kubectl cordon {}'
+    # Gracefully shutdown workers
+    printf "Shutting down workers:"
+    for NUM in $(seq 1 $NWORKERS); do
+        printf " caasp4-worker-${NUM}"
+        vagrant ssh caasp4-worker-${NUM} -c 'sudo systemctl poweroff' 2> /dev/null
+    done
+    printf "\n"
+    
+    vagrant ssh caasp4-master-1 -c 'sudo -H -u sles bash -c "source /vagrant/utils.sh; wait_for_workers_notready"'
+    
+    # Gracefully shutdown masters
+    printf "Shutting down masters:"
+    for NUM in $(seq 1 $NMASTERS); do
+        printf " caasp4-master-${NUM}"
+        vagrant ssh caasp4-master-${NUM} -c 'sudo systemctl poweroff' 2>/dev/null
+    done
+    printf "\n"
+    
+    # Gracefully shutdown loadbalancers
+    printf "Shutting down loadbalancers:"
+    for NUM in $(seq 1 $NLOADBAL); do
+        printf " caasp4-lb-${NUM}"
+        vagrant ssh caasp4-lb-${NUM} -c 'sudo systemctl poweroff' 2>/dev/null
+    done
+    printf "\n"
+    
+    # Gracefully shutdown storage
+    printf "Shutting down storage:"
+    for NUM in $(seq 1 $NSTORAGE); do
+        printf " caasp4-storage-${NUM}"
+        vagrant ssh caasp4-storage-${NUM} -c 'sudo systemctl poweroff' 2>/dev/null
+    done
+    printf "\n"
+    
+	$VERBOSE && set +x
+
+}
+
+
+if [[ $# -ne 1 ]]; then
+	printf "This tool takes one argument, no more, no less!\n" >&2
+	exit 1
+fi
+
+case $1 in
+	start)
+	    start_cluster
+		;;
+    stop)
+        stop_cluster
+		;;
+	getToken)
+		vagrant ssh caasp4-master-1 -c 'ST=$(sudo -H -u sles kubectl -n kube-system get serviceaccounts admin-user -o jsonpath="{.secrets[0].name}");sudo -H -u sles kubectl -n kube-system get secret ${ST} -o jsonpath="{.data.token}"|base64 -d' 2>/dev/null
+		;;
+	?*)
+        printf "'$1' is not a valid command\n" >&2
+		exit 1
+		;;
+esac

--- a/cluster.sh
+++ b/cluster.sh
@@ -4,13 +4,13 @@ source caasp_env.conf
 function printHelp {
 cat << EOF
 Usage ${0##*/} [options..] [command]
--v, --verbose        Make the operation more talkative
--h,-?, --help        Show help and exit
+-v, --verbose       Make the operation more talkative
+-h,-?, --help       Show help and exit
 
-start                start a previosly provisioned cluster
-stop                 stop a running cluster
+start               start a previosly provisioned cluster
+stop                stop a running cluster
 
-getToken             get Dashboard token
+dashboardInfo       get Dashboard IP, PORT and Token
 EOF
 }
 
@@ -40,53 +40,53 @@ while :; do
 done
 
 function start_cluster {
-	$VERBOSE && set -x
+    $VERBOSE && set -x
     # start loadbalancers
     printf "Starting loadbalancers:\n"
     for NUM in $(seq 1 $NLOADBAL); do
         vagrant reload caasp4-lb-${NUM}
     done
     printf "\n"
-    
+
     # Starting storage
     printf "Starting storage:\n"
     for NUM in $(seq 1 $NSTORAGE); do
         vagrant reload caasp4-storage-${NUM}
     done
     printf "\n"
-    
+
     printf "Staring master nodes\n"
     for NUM in $(seq 1 $NMASTERS); do
         vagrant reload caasp4-master-${NUM}
     done
-    
+
     #Waiting for masters to become ready
     vagrant ssh caasp4-master-1 -c 'sudo -H -u sles bash -c "source /vagrant/utils.sh; wait_for_masters_ready"'
-    
+
     printf "Staring worker nodes\n"
     for NUM in $(seq 1 $NWORKERS); do
         vagrant reload caasp4-worker-${NUM}
     done
-    
+
     # Waiting for workers to become ready
     vagrant ssh caasp4-master-1 -c 'sudo -H -u sles bash -c "source /vagrant/utils.sh; wait_for_workers_ready"'
-    
+
     printf "Starting scheduling on nodes.\n"
     vagrant ssh caasp4-master-1 -c 'sudo -H -u sles kubectl get nodes -o name | \
-      sudo -H -u sles xargs -I{} kubectl uncordon {}'
-    
+        sudo -H -u sles xargs -I{} kubectl uncordon {}'
+
     printf "Cluster is up and running.....\n"
-	$VERBOSE && set +x
+    $VERBOSE && set +x
 
 }
 
 function stop_cluster {
-	$VERBOSE && set -x
+    $VERBOSE && set -x
     # Disable scheduling on the whole cluster. 
     # This will avoid Kubernetes rescheduling jobs while you are shutting down nodes
     printf "Disabling scheduling on cluster nodes:\n"
     vagrant ssh caasp4-master-1 -c 'sudo -H -u sles kubectl get nodes -o name | \
-      sudo -H -u sles xargs -I{} kubectl cordon {}'
+        sudo -H -u sles xargs -I{} kubectl cordon {}'
     # Gracefully shutdown workers
     printf "Shutting down workers:"
     for NUM in $(seq 1 $NWORKERS); do
@@ -94,9 +94,9 @@ function stop_cluster {
         vagrant ssh caasp4-worker-${NUM} -c 'sudo systemctl poweroff' 2> /dev/null
     done
     printf "\n"
-    
+
     vagrant ssh caasp4-master-1 -c 'sudo -H -u sles bash -c "source /vagrant/utils.sh; wait_for_workers_notready"'
-    
+
     # Gracefully shutdown masters
     printf "Shutting down masters:"
     for NUM in $(seq 1 $NMASTERS); do
@@ -104,7 +104,7 @@ function stop_cluster {
         vagrant ssh caasp4-master-${NUM} -c 'sudo systemctl poweroff' 2>/dev/null
     done
     printf "\n"
-    
+
     # Gracefully shutdown loadbalancers
     printf "Shutting down loadbalancers:"
     for NUM in $(seq 1 $NLOADBAL); do
@@ -112,7 +112,7 @@ function stop_cluster {
         vagrant ssh caasp4-lb-${NUM} -c 'sudo systemctl poweroff' 2>/dev/null
     done
     printf "\n"
-    
+
     # Gracefully shutdown storage
     printf "Shutting down storage:"
     for NUM in $(seq 1 $NSTORAGE); do
@@ -120,29 +120,37 @@ function stop_cluster {
         vagrant ssh caasp4-storage-${NUM} -c 'sudo systemctl poweroff' 2>/dev/null
     done
     printf "\n"
-    
-	$VERBOSE && set +x
+
+    $VERBOSE && set +x
+}
+
+function get_dashboard_credentials {
+    local NODE_PORT="$(vagrant ssh caasp4-master-1 -c 'sudo -H -u sles kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services kubernetes-dashboard -n kube-system' 2>/dev/null)" 
+    local NODE_IP="$(vagrant ssh caasp4-master-1 -c 'sudo -H -u sles kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}" -n kube-system' 2>/dev/null)"
+    local SECRET="$(vagrant ssh caasp4-master-1 -c 'ST=$(sudo -H -u sles kubectl -n kube-system get serviceaccounts admin-user -o jsonpath="{.secrets[0].name}");sudo -H -u sles kubectl -n kube-system get secret ${ST} -o jsonpath="{.data.token}"|base64 -d' 2>/dev/null)"
+    printf "Access your dashboard at: https://$NODE_IP:$NODE_PORT/\n"
+    printf "Your login token is: ${SECRET}\n"
 
 }
 
 
 if [[ $# -ne 1 ]]; then
-	printf "This tool takes one argument, no more, no less!\n" >&2
-	exit 1
+    printf "This tool takes one argument, no more, no less!\n" >&2
+    exit 1
 fi
 
 case $1 in
-	start)
-	    start_cluster
-		;;
+    start)
+        start_cluster
+        ;;
     stop)
         stop_cluster
-		;;
-	getToken)
-		vagrant ssh caasp4-master-1 -c 'ST=$(sudo -H -u sles kubectl -n kube-system get serviceaccounts admin-user -o jsonpath="{.secrets[0].name}");sudo -H -u sles kubectl -n kube-system get secret ${ST} -o jsonpath="{.data.token}"|base64 -d' 2>/dev/null
-		;;
-	?*)
+        ;;
+    dashboardInfo)
+        get_dashboard_credentials
+        ;;
+    ?*)
         printf "'$1' is not a valid command\n" >&2
-		exit 1
-		;;
+        exit 1
+        ;;
 esac

--- a/deploy/04.add_workers.sh
+++ b/deploy/04.add_workers.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 cd /vagrant/cluster/caasp4-cluster
 source /vagrant/caasp_env.conf
+source /vagrant/utils.sh
 echo "Adding workers..."
 set -x
 for NUM in $(seq 1 $NWORKERS); do
     skuba node join --role worker --user sles --sudo --target caasp4-worker-${NUM} caasp4-worker-${NUM}
 done
-
+set +x
+wait_for_masters_ready
+wait_for_workers_ready
+set -x
 skuba cluster status
 kubectl get nodes -o wide
 set +x

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${SCRIPTDIR}"/caasp_env.conf
+
+function wait_for_masters_ready {
+    printf "Waiting for masters to be ready"
+    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "caasp4-master-[0-9]\s+Ready") -eq $NMASTERS ]]; do
+         sleep 5
+		 printf "."
+    done
+	printf "\n"
+}
+
+function wait_for_workers_ready {
+    printf "Waiting for workers to be ready"
+    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "caasp4-worker-[0-9]\s+Ready") -eq $NWORKERS ]]; do
+         sleep 5
+         printf "."
+    done
+    printf "\n"
+}
+
+function wait_for_workers_notready {
+    printf "Waiting for workers to be flagged 'NotReady'"
+    until [[ $(kubectl get nodes 2>/dev/null | egrep -c "caasp4-worker-[0-9]\s+NotReady") -eq $NWORKERS ]]; do
+         sleep 5
+         printf "."
+    done
+    printf "\n"
+}


### PR DESCRIPTION
Here's a suggestion for a script that can start/stop a running cluster
```
Usage cluster.sh [options..] [command]
-v, --verbose        Make the operation more talkative
-h,-?, --help        Show help and exit

start                start a previosly provisioned cluster
stop                 stop a running cluster

getToken             get Dashboard token
```
Sometimes, due to bad network connection, it takes some time for master and workers to reach **Ready** state when I deploy a new cluster. When that happens and you run `deploy_caasp.sh --full` it fails to install tiller, nfs-client-provisioner and the dashboard.

I added _wait_for_masters_ready_ and _wait_for_workers_ready_ in _04.add_workers.sh _ so the deployment waits until the cluster is in a Ready state before continue.

Please let me know if you suggests changes.
Fixes #14 