### PR TITLE
removed hardcoded bridge name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ cd vagrant-caasp
 # NETWORK SETUP (As root)
 ```sh
 # Fresh vagrant-libvirt setup
-# NOTE: this assumes device virbr1 is available - update file if needed
 virsh net-create ./libvirt_setup/vagrant-libvirt.xml
 # _or_ if you already have the vagrant-libvirt network
 ./libvirt_setup/add_hosts_to_net.sh

--- a/libvirt_setup/vagrant-libvirt.xml
+++ b/libvirt_setup/vagrant-libvirt.xml
@@ -5,7 +5,7 @@
       <port start='1024' end='65535'/>
     </nat>
   </forward>
-  <bridge name='virbr1' stp='on' delay='0'/>
+  <bridge stp='on' delay='0'/>
   <mac address='52:54:00:5f:50:88'/>
   <dns>
     <host ip='192.168.121.111'>


### PR DESCRIPTION
By just removing the bridge name from the vagrant-libvirt.xml file libvirt will use a free bridge name.
I've tested this several times and it "works for me"™

The  /libvirt_setup/update_firewall.sh already fetches the bridge name and I couldn't find other places than README.md that refereed to the static name virbr1

Fixes #17 