### PR TITLE
Fix a problem with owner and permissions

### DIFF
--- a/boxfiles/generate_key.sh
+++ b/boxfiles/generate_key.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -x
 if [ ! -f cluster/caasp4-id ]; then
     ssh-keygen -t rsa -f cluster/caasp4-id -P ''
+    chown sles:users cluster/caasp4-id
 fi
 

--- a/boxfiles/prep_box.sh
+++ b/boxfiles/prep_box.sh
@@ -1,11 +1,4 @@
 #!/bin/bash 
-if [ ! -d /vagrant/cluster ]; then
-    mkdir /vagrant/cluster
-fi
-
-if [ ! -f /vagrant/cluster/caasp4-id ]; then
-    ssh-keygen -t rsa -f /vagrant/cluster/caasp4-id -P ''
-fi
 
 useradd -m sles
 echo "sles ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/sles
@@ -19,3 +12,13 @@ chown -R sles ~sles/.ssh
 myip=$(ip a sh eth0|sed -n 's;.*inet \(.*\)/.*;\1;p')
 echo ${myip} $(hostname -f) $(hostname -s)
 
+if [ ! -d /vagrant/cluster ]; then
+    mkdir /vagrant/cluster
+    chown -R sles:users /vagrant/cluster
+fi
+
+if [ ! -f /vagrant/cluster/caasp4-id ]; then
+    ssh-keygen -t rsa -f /vagrant/cluster/caasp4-id -P ''
+    chown sles:users /vagrant/cluster/caasp4-id
+    chown sles:users /vagrant/cluster/caasp4-id.pub
+fi


### PR DESCRIPTION
This patch changes the order in which we create the
/vagrant/cluster/caasp4-id and pub files, so we can
properly set the owner permissions on them.

This resolves:
https://github.com/sigsteve/vagrant-caasp/issues/45