### PR TITLE
Removed zypper version check

### DIFF
--- a/libvirt_setup/openSUSE_vagrant_setup.sh
+++ b/libvirt_setup/openSUSE_vagrant_setup.sh
@@ -2,15 +2,7 @@
 
 set -ex
 
-# install vagrant and it dependencies, devel files to build vagrant plugins later
-# use new --allow-unsigned-rpm option if zypper supports it
-zypper_version=($(zypper -V))
-if [[ ${zypper_version[1]} < '1.14.4' ]]
-then
-    zypper --no-gpg-checks in -y https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_x86_64.rpm
-else
-    zypper in -y --allow-unsigned-rpm https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_x86_64.rpm
-fi
+zypper in -y --allow-unsigned-rpm https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_x86_64.rpm
 
 # workaround for https://github.com/hashicorp/vagrant/issues/10019
 mv /opt/vagrant/embedded/lib/libreadline.so.7{,.disabled} | true


### PR DESCRIPTION
It seems like this code is redundant and unnecessary. According to instructions you need [leap 15+](https://github.com/sigsteve/vagrant-caasp#assumptions)  and the oss-repository contains [version 1.14.5](http://download.opensuse.org/distribution/leap/15.0/repo/oss/x86_64/)
So accoring to my findings, [this line](https://github.com/sigsteve/vagrant-caasp/blob/2497af9968f18c11019ab0668c895da0954866b9/libvirt_setup/openSUSE_vagrant_setup.sh#L8) would never be evaluated as true.