### PR TITLE
Add openstack directory

### DIFF
--- a/openstack/000.zypper_repos.sh
+++ b/openstack/000.zypper_repos.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# sudo this file
+
+echo "alias ll='ls -al'" >> ~sles/.bashrc
+
+zypper ar http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard SLE15-SP1-GA
+zypper ar http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/ SLE15-SP1-Update
+
+zypper ar http://download.suse.de/install/SLP/SLE-15-SP1-Module-Development-Tools-GM/x86_64/DVD1/ SLE15-DEV-DVD1
+zypper ar http://download.suse.de/install/SLP/SLE-15-SP1-Module-Development-Tools-GM/x86_64/DVD2/ SLE15-DEV-DVD2
+zypper ar http://download.suse.de/install/SLP/SLE-15-SP1-Module-Development-Tools-GM/x86_64/DVD3/ SLE15-DEV-DVD3
+
+zypper ar http://download.suse.de/install/SLP/SLE-15-SP1-Module-Basesystem-GM/x86_64/DVD1/ SLE15-SP1-BASE1
+zypper ar http://download.suse.de/install/SLP/SLE-15-SP1-Module-Basesystem-GM/x86_64/DVD2/ SLE15-SP1-BASE2
+zypper ar http://download.suse.de/install/SLP/SLE-15-SP1-Module-Basesystem-GM/x86_64/DVD3/ SLE15-SP1-BASE3
+zypper refresh

--- a/openstack/001.install_packages.sh
+++ b/openstack/001.install_packages.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sudo zypper in -y wget make python3-pip jq bc
+
+sudo pip install -U pip
+sudo pip install "cmd2<=0.8.7"
+sudo pip install python-openstackclient python-heatclient --ignore-installed

--- a/openstack/002.setup_hosts.sh
+++ b/openstack/002.setup_hosts.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# this script adds the required entries to the /etc/hosts file
+
+
+tee -a /etc/hosts <<EOF
+192.168.121.169    keystone    keystone.openstack.svc.cluster.local
+192.168.121.169    glance      glance.openstack.svc.cluster.local
+192.168.121.169    cinder      cinder.openstack.svc.cluster.local
+192.168.121.169    nova        nova.openstack.svc.cluster.local
+192.168.121.169    neutron     neutron.openstack.svc.cluster.local
+192.168.121.169    horizon     horizon.openstack.svc.cluster.local
+192.168.121.169    heat        heat.openstack.svc.cluster.local
+EOF

--- a/openstack/050.install_helm_service.sh
+++ b/openstack/050.install_helm_service.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Sudo this script
+
+# Only run this after helm is installed 
+touch /etc/systemd/system/helm-serve.service
+cat >/etc/systemd/system/helm-serve.service <<EOF
+[Unit]
+Description=Helm Server
+After=network.target
+
+[Service]
+User=sles
+Restart=always
+ExecStart=/usr/bin/helm serve
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+chmod 664 /etc/systemd/system/helm-serve.service
+systemctl daemon-reload
+sleep 1
+systemctl start helm-serve
+sleep 1
+systemctl status helm-serve
+sleep 2
+
+sudo -u sles helm repo add local http://localhost:8879/charts

--- a/openstack/051.setup_openstack_client.sh
+++ b/openstack/051.setup_openstack_client.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+mkdir -p /etc/openstack
+chown -R $(id -un): /etc/openstack
+tee /etc/openstack/clouds.yaml << EOF
+clouds:
+  openstack_helm:
+    region_name: RegionOne
+    identity_api_version: 3
+    auth:
+      username: 'admin'
+      password: 'password'
+      project_name: 'admin'
+      project_domain_name: 'default'
+      user_domain_name: 'default'
+      auth_url: 'http://keystone.openstack.svc.cluster.local/v3'
+EOF

--- a/openstack/052.clone_upstream_helm_charts.sh
+++ b/openstack/052.clone_upstream_helm_charts.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -xe
+
+cd ~sles
+if [ ! -d ~sles/openstack-helm-infra ]; then
+  git clone https://opendev.org/openstack/openstack-helm-infra.git
+fi
+cd ~sles/openstack-helm-infra
+make all
+
+cd ~sles
+if [ ! -d ~sles/openstack-helm ]; then
+  git clone https://opendev.org/openstack/openstack-helm.git
+fi
+cd ~sles/openstack-helm
+make all

--- a/openstack/053.patch-03-ingress.sh
+++ b/openstack/053.patch-03-ingress.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This script patches the 030-ingress.sh standup script
+# so that we have a consistent ingress VIP so we can have
+# our openstack services on
+cd ~sles/openstack-helm
+
+git apply /vagrant/openstack/patch-030-ingress.patch

--- a/openstack/101.setup_kube_stuff.sh
+++ b/openstack/101.setup_kube_stuff.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+
+# This script does some setup of kube shit before trying
+# to deploy any helm charts.
+source /vagrant/caasp_env.conf
+
+set -x
+for NUM in $(seq 1 $NWORKERS); do
+  kubectl label nodes caasp4-worker-${NUM} openstack-control-plane=enabled
+  kubectl label nodes caasp4-worker-${NUM} openstack-compute-node=enabled
+done
+
+kubectl label nodes caasp4-worker-1 openvswitch=enabled
+kubectl label nodes caasp4-worker-1 openstack-helm-node-class=primary
+
+tee /tmp/suse-sa-clusterrolebindings.yml <<EOF
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: PrivilegedRoleBinding
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+# Authorize specific service accounts:
+- kind: ServiceAccount
+  name: cinder-backup
+  namespace: openstack
+- kind: ServiceAccount
+  name: nova-novncproxy
+  namespace: openstack
+- kind: ServiceAccount
+  name: openvswitch-vswitchd
+  namespace: openstack
+- kind: ServiceAccount
+  name: libvirt 
+  namespace: openstack
+- kind: ServiceAccount
+  name: neutron-dhcp-agent
+  namespace: openstack
+- kind: ServiceAccount
+  name: neutron-l3-agent
+  namespace: openstack
+- kind: ServiceAccount
+  name: neutron-metadata-agent
+  namespace: openstack
+- kind: ServiceAccount
+  name: nova-compute
+  namespace: openstack
+- kind: ServiceAccount
+  name: neutron-ovs-agent
+  namespace: openstack
+- kind: ServiceAccount
+  name: openvswitch-db
+  namespace: openstack
+- kind: ServiceAccount
+  name: ingress-kube-system-ingress
+  namespace: kube-system
+- kind: ServiceAccount
+  name: nfs-provisioner-nfs-provisioner
+  namespace: nfs
+EOF
+kubectl apply -f /tmp/suse-sa-clusterrolebindings.yml

--- a/openstack/102.deploy_ingress.sh
+++ b/openstack/102.deploy_ingress.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/common/030-ingress.sh

--- a/openstack/103.deploy_nfs.sh
+++ b/openstack/103.deploy_nfs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/040-nfs-provisioner.sh

--- a/openstack/104.deploy_mariadb.sh
+++ b/openstack/104.deploy_mariadb.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/050-mariadb.sh

--- a/openstack/105.deploy_rabbitMQ.sh
+++ b/openstack/105.deploy_rabbitMQ.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/060-rabbitmq.sh

--- a/openstack/106.deploy_memcached.sh
+++ b/openstack/106.deploy_memcached.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/070-memcached.sh

--- a/openstack/107.deploy_keystone.sh
+++ b/openstack/107.deploy_keystone.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/080-keystone.sh

--- a/openstack/108.deploy_heat.sh
+++ b/openstack/108.deploy_heat.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/090-heat.sh

--- a/openstack/109.deploy_horizon.sh
+++ b/openstack/109.deploy_horizon.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/100-horizon.sh

--- a/openstack/110.deploy_glance.sh
+++ b/openstack/110.deploy_glance.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/120-glance.sh

--- a/openstack/111.deploy_cinder.sh
+++ b/openstack/111.deploy_cinder.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+echo "There is no cinder nfs yet"
+
+#./tools/deployment/developer/nfs/130-cinder.sh

--- a/openstack/112.deploy_openvswitch.sh
+++ b/openstack/112.deploy_openvswitch.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/140-openvswitch.sh

--- a/openstack/113.deploy_libvirt.sh
+++ b/openstack/113.deploy_libvirt.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/150-libvirt.sh

--- a/openstack/114.deploy_compute_kit.sh
+++ b/openstack/114.deploy_compute_kit.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/160-compute-kit.sh

--- a/openstack/115.setup_public_gateway.sh
+++ b/openstack/115.setup_public_gateway.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xe
+
+cd ~sles/openstack-helm
+
+./tools/deployment/developer/nfs/170-setup-gateway.sh

--- a/openstack/200.run-all.sh
+++ b/openstack/200.run-all.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+STEPS=16
+STEP=1
+
+function showstep {
+    echo "Step $STEP of $STEPS"
+    STEP=$STEP+1
+}
+
+
+showstep
+sudo ./000.zypper_repos.sh
+showstep
+./001.install_packages.sh
+showstep
+./002.setup_hosts.sh
+
+showstep
+sudo ./050.install_helm_service.sh
+showstep
+sudo ./051.setup_openstack_client.sh
+showstep
+./052.clone_upstream_helm_charts.sh
+showstep
+./053.patch-03-ingress.sh
+
+
+showstep
+./101.setup_kube_stuff.sh
+showstep
+./102.deploy_ingress.sh
+showstep
+./103.deploy_nfs.sh
+showstep
+./104.deploy_mariadb.sh
+showstep
+./105.deploy_rabbitMQ.sh
+showstep
+./106.deploy_memcached.sh
+showstep
+./107.deploy_keystone.sh
+showstep
+./108.deploy_heat.sh
+showstep
+./109.deploy_horizon.sh
+showstep
+./110.deploy_glance.sh

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -1,0 +1,45 @@
+# Bootstrap a running kubernetes with OpenStack
+
+This directory contains some scripts in order, to run on 
+a caasp4-worker-1 node.   These scripts do the work
+as described in the upstream openstack helm tutorial
+for setting up kubernetes to deploy helm charts.  
+
+The scripts pull down openstack-helm-infra and openstack-helm,
+build all the charts and uses them to deploy some OpenStack
+services.
+
+# Requirements
+It's assumed that you have either deployed the caasp4 kube with
+deploy_caasp.sh --full or have run all of the scripts manually in
+/vagrant/deploy.
+
+# Services
+
+The following are services that have been verified to work.
+* mariadb
+* memcached
+* keystone
+* heat
+* horizon
+* glance
+
+
+# Scripts
+
+You can either run the scripts manually or by running
+the 200.run-all.sh script.  If you run the scripts manually,
+some of them require sudo and others don't.  You'll have to look
+inside them to determine which is which.
+
+The 200.run-all.sh script will run all the scripts up through
+and including the deploy_glance.sh script.   I haven't been able
+to get the helm charts after glance to deploy correctly.
+
+# kubernetes dashboard
+You can run the discover_dashboard_port.sh script to find out what port
+the Kubernetes dashboard is running on.  This port seems to change every 
+time you deploy kube. The dashboard will be on http://192.168.121.120:<PORT>
+
+To login cat the ~/.kube/config file and use the token at the bottom of the
+file as the auth token.

--- a/openstack/discover_dashboard_port.sh
+++ b/openstack/discover_dashboard_port.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Kube Dashboard port = "
+kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services kubernetes-dashboard -n kube-system
+echo ""

--- a/openstack/patch-030-ingress.patch
+++ b/openstack/patch-030-ingress.patch
@@ -1,0 +1,19 @@
+diff --git a/tools/deployment/developer/common/030-ingress.sh b/tools/deployment/developer/common/030-ingress.sh
+index a92f94d5..59c61af8 100755
+--- a/tools/deployment/developer/common/030-ingress.sh
++++ b/tools/deployment/developer/common/030-ingress.sh
+@@ -31,6 +31,14 @@ deployment:
+   type: DaemonSet
+ network:
+   host_namespace: true
++  vip:
++    manage: true
++    # what type of vip manage mechanism will be used
++    # possible options: routed, keepalived
++    mode: routed
++    interface: ingress-vip
++    addr: 192.168.121.169/32
++  external_policy_local: true
+ EOF
+ helm upgrade --install ingress-kube-system ${HELM_CHART_ROOT_PATH}/ingress \
+   --namespace=kube-system \


### PR DESCRIPTION
These scripts do the work as described in the upstream
openstack helm tutorial for setting up kubernetes to deploy
helm charts.  Run these scripts on the master node.

The scripts pull down openstack-helm-infra and openstack-helm,
build all the charts and uses them to deploy some OpenStack
services.