### PR TITLE
Allow all users to read the kubeconfig

### DIFF
--- a/boxfiles/prep_box.sh
+++ b/boxfiles/prep_box.sh
@@ -7,7 +7,7 @@ mkdir -p ~sles/.ssh
 
 if [ ! -d /vagrant/cluster ]; then
     mkdir /vagrant/cluster
-    chown -R sles /vagrant/cluster
+    chown -R sles:users /vagrant/cluster
 fi
 
 if [ ! -f /vagrant/cluster/caasp4-id ]; then

--- a/deploy/01.init_cluster.sh
+++ b/deploy/01.init_cluster.sh
@@ -9,4 +9,5 @@ rm -fr caasp4-cluster 2>/dev/null
 echo "Initializing cluster..."
 set -x
 skuba cluster init --control-plane caasp4-lb-1 caasp4-cluster
+chmod g+rx caasp4-cluster
 set +x

--- a/deploy/02.bootstrap_cluster.sh
+++ b/deploy/02.bootstrap_cluster.sh
@@ -8,6 +8,7 @@ skuba cluster status
 set +x
 mkdir ~/.kube
 ln -sf /vagrant/cluster/caasp4-cluster/admin.conf ~/.kube/config
+chmod g+r /vagrant/cluster/caasp4-cluster/admin.conf
 
 set -x
 kubectl get nodes -o wide


### PR DESCRIPTION
This makes it easier to interact with the deployed kube cluster.

I assume that since this is vagrant only, we don't care _that_ much about not letting other people access the cluster.  So this makes the cluster directory have the `users` group, and group-readable `admin.conf`.

It just seems easier than having to `vagrant ssh` or `sudo` to get at the file so I can actually access the cluster.

It might also be a good idea to document where this file lives in the readme, so that it's easier to get started.