### PR TITLE
Allow configuration of additional disks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,9 +37,14 @@ Vagrant.configure("2") do |config|
                 linux__nfs_options: ['rw','no_subtree_check','no_root_squash','async']
             sle.vm.provider :libvirt do |lv|
                 lv.management_network_mac = "52:50:05:AA:01:0#{i}"
-                #lv.storage :file, :size => '20G'
                 lv.memory = config_yml[CONFIG_MODEL]['nodes']['master']['memory']
                 lv.cpus   = config_yml[CONFIG_MODEL]['nodes']['master']['cpus']
+                extra_disks = config_yml[CONFIG_MODEL]['nodes']['master']['extra_disks']
+                if extra_disks > 0
+                    (1..extra_disks).each do |disk_num|
+                      lv.storage :file, :size => config_yml[CONFIG_MODEL]['nodes']['master']['disk_size']
+                    end
+                end
             end
         end
     end
@@ -55,7 +60,12 @@ Vagrant.configure("2") do |config|
                 linux__nfs_options: ['rw','no_subtree_check','no_root_squash','async']
             sle.vm.provider :libvirt do |lv|
                 lv.management_network_mac = "52:50:05:AA:02:0#{i}"
-                #lv.storage :file, :size => '20G'
+                extra_disks = config_yml[CONFIG_MODEL]['nodes']['worker']['extra_disks']
+                if extra_disks > 0
+                    (1..extra_disks).each do |disk_num|
+                      lv.storage :file, :size => config_yml[CONFIG_MODEL]['nodes']['worker']['disk_size']
+                    end
+                end
                 lv.memory = config_yml[CONFIG_MODEL]['nodes']['worker']['memory']
                 lv.cpus   = config_yml[CONFIG_MODEL]['nodes']['worker']['cpus']
             end
@@ -74,6 +84,12 @@ Vagrant.configure("2") do |config|
                 lv.management_network_mac = "52:50:05:AA:03:0#{i}"
                 lv.memory = config_yml[CONFIG_MODEL]['nodes']['loadbalancer']['memory']
                 lv.cpus   = config_yml[CONFIG_MODEL]['nodes']['loadbalancer']['cpus']
+                extra_disks = config_yml[CONFIG_MODEL]['nodes']['loadbalancer']['extra_disks']
+                if extra_disks > 0
+                    (1..extra_disks).each do |disk_num|
+                      lv.storage :file, :size => config_yml[CONFIG_MODEL]['nodes']['loadbalancer']['disk_size']
+                    end
+                end
             end
         end
     end
@@ -90,6 +106,12 @@ Vagrant.configure("2") do |config|
                 lv.management_network_mac = "52:50:05:AA:04:0#{i}"
                 lv.memory = config_yml[CONFIG_MODEL]['nodes']['storage']['memory']
                 lv.cpus   = config_yml[CONFIG_MODEL]['nodes']['storage']['cpus']
+                extra_disks = config_yml[CONFIG_MODEL]['nodes']['storage']['extra_disks']
+                if extra_disks > 0
+                    (1..extra_disks).each do |disk_num|
+                      lv.storage :file, :size => config_yml[CONFIG_MODEL]['nodes']['storage']['disk_size']
+                    end
+                end
             end
         end
     end

--- a/config.yml
+++ b/config.yml
@@ -2,91 +2,101 @@
 # This configuration file is used to describe different sizes
 # of deployments.
 #
+# For each node type define:
+# count: Number of nodes of this type
+# cpus: Number of CPUs for node
+# memory: RAM for node
+# extra_disks: Number of extra disks (vdb, vdc) to create,
+#              each will have a size of 'disk_Size'
+# disk_size: Size of extra disks
 minimal:
   nodes:
     master:
       count: 1
       cpus: 2
       memory: 2048
-      storage: 20G
+      extra_disks: 0
     worker:
       count: 1
       cpus: 2
       memory: 2048
-      storage: 20G
+      extra_disks: 0
     loadbalancer:
       count: 1
       cpus: 1
       memory: 512
-      storage: 20G
+      extra_disks: 0
     storage:
       count: 1
       cpus: 1
       memory: 512
-      storage: 20G
+      extra_disks: 0
 small:
   nodes:
     master:
       count: 1
       cpus: 2
       memory: 2048
-      storage: 20G
+      extra_disks: 0
     worker:
       count: 2
       cpus: 2
       memory: 2048
-      storage: 20G
+      extra_disks: 0
     loadbalancer:
       count: 1
       cpus: 1
       memory: 1024
-      storage: 20G
+      extra_disks: 0
     storage:
       count: 1
       cpus: 1
       memory: 1024
-      storage: 20G
+      extra_disks: 0
 medium:
   nodes:
     master:
       count: 3
       cpus: 2
       memory: 4096
-      storage: 20G
+      extra_disks: 0
     worker:
       count: 3
       cpus: 4
       memory: 16384
-      storage: 20G
+      extra_disks: 0
     loadbalancer:
       count: 1
       cpus: 2
       memory: 4096
-      storage: 20G
+      extra_disks: 0
     storage:
       count: 1
       cpus: 2
       memory: 4096
-      storage: 20G
+      extra_disks: 0
 large:
   nodes:
     master:
       count: 3
       cpus: 4
       memory: 8192
-      storage: 20G
+      extra_disks: 1
+      disk_size: 20G
     worker:
       count: 5
       cpus: 4
       memory: 16384
-      storage: 80G
+      extra_disks: 1
+      disk_size: 80G
     loadbalancer:
       count: 1
       cpus: 2
       memory: 8192
-      storage: 20G
+      extra_disks: 0
     storage:
       count: 1
       cpus: 2
       memory: 8192
-      storage: 100G
+      extra_disks: 1
+      disk_size: 100G


### PR DESCRIPTION
Allow to create additional disks, each with the same size, per node
type. Add this for large setup, following the indent of the "storage"
parameter.

Remove the unused "storage" parameter from config.yml.