### PR TITLE
Fix model selection

### DIFF
--- a/deploy_caasp.sh
+++ b/deploy_caasp.sh
@@ -85,7 +85,7 @@ fi
 
 # This is so Vagrantfile can read the
 # selected model
-export $CAASP_CONFIG_MODEL
+export CAASP_CONFIG_MODEL
 
 # read in the config.yml and write out the caasp_env.conf
 source lib.sh


### PR DESCRIPTION
export needs a variable without $, this fixes the passing of the
environment variable to the Vagrantfile.

Without this change, the Vagrantfile would always use the "minimal"
setup.