### PR TITLE
Add a -v option to deploy_caasp.sh and pass through to skuba sigsteve/vagrant-caasp/issues/79

### DIFF
--- a/deploy/01.init_cluster.sh
+++ b/deploy/01.init_cluster.sh
@@ -1,4 +1,6 @@
-#!/bin/bash 
+#!/bin/bash
+. /vagrant/deploy/util-args.sh
+
 if [ "$(hostname -s|grep -c master)" -ne 1 ]; then
     echo "This must be run on the master..."
     exit 1
@@ -8,6 +10,6 @@ cd /vagrant/cluster
 rm -fr caasp4-cluster 2>/dev/null
 echo "Initializing cluster..."
 set -x
-skuba cluster init --control-plane caasp4-lb-1 caasp4-cluster
+skuba cluster init -v $VERBOSITY --control-plane caasp4-lb-1 caasp4-cluster
 chmod g+rx caasp4-cluster
 set +x

--- a/deploy/02.bootstrap_cluster.sh
+++ b/deploy/02.bootstrap_cluster.sh
@@ -1,10 +1,12 @@
 #!/bin/bash 
+. /vagrant/deploy/util-args.sh
+
 cd /vagrant/cluster/caasp4-cluster
 echo "Bootstrapping cluster..."
 set -x
-skuba node bootstrap --user sles --sudo --target caasp4-master-1 caasp4-master-1
+skuba node bootstrap --user sles -v $VERBOSITY --sudo --target caasp4-master-1 caasp4-master-1
 
-skuba cluster status
+skuba cluster status -v $VERBOSITY
 set +x
 mkdir ~/.kube
 ln -sf /vagrant/cluster/caasp4-cluster/admin.conf ~/.kube/config

--- a/deploy/03.add_masters.sh
+++ b/deploy/03.add_masters.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 . /vagrant/caasp_env.conf
+. /vagrant/deploy/util-args.sh
 
 cd /vagrant/cluster/caasp4-cluster
 echo "Adding additional masters..."
 set -x
 for NUM in $(seq 2 $NMASTERS); do
-    skuba node join --role master --user sles --sudo --target caasp4-master-${NUM} caasp4-master-${NUM}
+    skuba node join -v $VERBOSITY --role master --user sles --sudo --target caasp4-master-${NUM} caasp4-master-${NUM}
 done
-skuba cluster status
+skuba cluster status -v $VERBOSITY
 kubectl get nodes -o wide
 set +x

--- a/deploy/04.add_workers.sh
+++ b/deploy/04.add_workers.sh
@@ -2,15 +2,16 @@
 cd /vagrant/cluster/caasp4-cluster
 source /vagrant/caasp_env.conf
 source /vagrant/utils.sh
+. /vagrant/deploy/util-args.sh
 echo "Adding workers..."
 set -x
 for NUM in $(seq 1 $NWORKERS); do
-    skuba node join --role worker --user sles --sudo --target caasp4-worker-${NUM} caasp4-worker-${NUM}
+    skuba node join -v $VERBOSITY --role worker --user sles --sudo --target caasp4-worker-${NUM} caasp4-worker-${NUM}
 done
 set +x
 wait_for_masters_ready
 wait_for_workers_ready
 set -x
-skuba cluster status
+skuba cluster status -v $VERBOSITY
 kubectl get nodes -o wide
 set +x

--- a/deploy/98.status.sh
+++ b/deploy/98.status.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
+. /vagrant/deploy/util-args.sh
 kubectl get po -A
 kubectl get no
 cd /vagrant/cluster/caasp4-cluster
-skuba cluster status
+skuba cluster status -v $VERBOSITY

--- a/deploy/99.run-all.sh
+++ b/deploy/99.run-all.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 eval $(ssh-agent -s)
 ssh-add /vagrant/cluster/caasp4-id
+. /vagrant/deploy/util-args.sh
 . /vagrant/caasp_env.conf
 cd /vagrant/deploy
 
-./01.init_cluster.sh 
-./02.bootstrap_cluster.sh 
-./03.add_masters.sh 
-./04.add_workers.sh 
-./05.setup_helm.sh
+./01.init_cluster.sh -v $VERBOSITY
+./02.bootstrap_cluster.sh -v $VERBOSITY
+./03.add_masters.sh -v $VERBOSITY
+./04.add_workers.sh -v $VERBOSITY
+./05.setup_helm.sh -v $VERBOSITY
 printf "Waiting for tiller to become available. This can take a couple of minutes."
 while [[ $(kubectl --namespace kube-system get pods | egrep -c "tiller-deploy-.* 1/1     Running") -eq 0 ]]
 do
@@ -16,14 +17,14 @@ do
     sleep 5
 done
 printf "\n"
-./06.add_k8s_nfs-sc.sh
-./07.add_dashboard.sh
-./08.add_metallb.sh
+./06.add_k8s_nfs-sc.sh -v $VERBOSITY
+./07.add_dashboard.sh -v $VERBOSITY
+./08.add_metallb.sh -v $VERBOSITY
 if [[ "${MODEL}" =~ "_rook" ]]; then
     echo "Setting up rook..."
     /vagrant/rook/rook_setup.sh
 fi
-./98.status.sh
+./98.status.sh -v $VERBOSITY
 ST=$(kubectl -n kube-system get serviceaccounts admin-user -o jsonpath="{.secrets[0].name}")
 SECRET=$(kubectl -n kube-system get secret ${ST} -o jsonpath="{.data.token}"|base64 -d)
 NODE_PORT=$(kubectl get -o jsonpath="{.spec.ports[0].nodePort}" services kubernetes-dashboard -n kube-system)

--- a/deploy/util-args.sh
+++ b/deploy/util-args.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+VERBOSITY="0"
+while (( "$#" )); do
+  case "$1" in
+    -v|--verbosity)
+      VERBOSITY=$2
+      if [[ $VERBOSITY == -* || ! $VERBOSITY ]]; then
+          # next parameter is not the verbosity number, so just set to 1
+          VERBOSITY="1"
+          shift
+      else
+          VERBOSITY=$2
+          shift 2
+      fi
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done

--- a/deploy_caasp.sh
+++ b/deploy_caasp.sh
@@ -4,12 +4,13 @@
 function printHelp {
 cat << EOF
 Usage ${0##*/} [options..]
--m, --model <model>  Which config.yml model to use for vm sizing
-                     Default: "minimal"
--f, --full           attempt to bring the machines up and deploy the cluster
--i, --ignore-memory  Don't prompt when over allocating memory
--t, --test           Do a dry run, don't actually deploy the vms.
--h,-?, --help        Show help
+-m, --model <model>     Which config.yml model to use for vm sizing
+                        Default: "minimal"
+-f, --full              attempt to bring the machines up and deploy the cluster
+-i, --ignore-memory     Don't prompt when over allocating memory
+-t, --test              Do a dry run, don't actually deploy the vms.
+-v, --verbosity <0-10>  Pass through verbosity level to skuba (default 0)
+-h,-?, --help           Show help
 EOF
 }
 
@@ -36,6 +37,7 @@ DO_MEMORY_CHECK=true
 FULL_DEPLOYMENT=false
 DO_DRY_RUN=false
 PARAMS=""
+VERBOSITY="0"
 while (( "$#" )); do
   case "$1" in
     -h|-\?|--help)
@@ -57,6 +59,17 @@ while (( "$#" )); do
     -t|--test)
       DO_DRY_RUN=true
       shift
+      ;;
+    -v|--verbosity)
+      VERBOSITY=$2
+      if [[ $VERBOSITY == -* || ! $VERBOSITY ]]; then
+          # next parameter is not the verbosity number, so just set to 1
+          VERBOSITY="1"
+          shift
+      else
+          VERBOSITY=$2
+          shift 2
+      fi
       ;;
     --) # end argument parsing
       shift
@@ -167,7 +180,7 @@ do
 done
 
 if [[ $FULL_DEPLOYMENT == true ]]; then
-    vagrant ssh caasp4-master-1 -c 'sudo su - sles -c /vagrant/deploy/99.run-all.sh'
+    vagrant ssh caasp4-master-1 -c 'sudo su - sles -c /vagrant/deploy/99.run-all.sh -v $VERBOSITY'
 fi
 
 echo "Happy CaaSPing!"


### PR DESCRIPTION
This adds some basic support for a -v [0-10] argument which
is then passed to the scripts in the deploy/ directory and then
on to the calls to skuba.

This commit only addresses calls to skuba, but a future commit
could extend to kubeadm or kubectl.

This is part of sigsteve/vagrant-caasp/issues/79