### PR TITLE
Updates to support CaaSP 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # vagrant-caasp -- BETA
-An automated deployment of SUSE CaaS Platform (Kubernetes) v4.1 for testing.
+An automated deployment of SUSE CaaS Platform (Kubernetes) v4.5 for testing.
 
 This project is a work in progress and will be cleaned up after some testing and feedback.
 Feel free to open issues and/or submit PRs.
@@ -44,10 +44,10 @@ virsh net-create ./libvirt_setup/vagrant-libvirt.xml
 # ADD BOX (As root)
 ```sh
 # Find the latest box at http://download.suse.de/ibs/home:/sbecht:/vc-test:/SLE-15-SP1/images/
-vagrant box add sle15sp1 \
+vagrant box add vagrant-caasp \
     http://download.suse.de/ibs/home:/sbecht:/vc-test:/SLE-15-SP1/images/<box>
 # _OR_
-# wget/curl the box and 'vagrant box add sle15sp1 </path/to/box>'
+# wget/curl the box and 'vagrant box add vagrant-caasp </path/to/box>'
 ```
 
 # OPTIONAL -- running as a user other than root

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
 
     1.upto(*mastercount) do |i|
         config.vm.define "caasp4-master-#{i}" do |sle|
-            sle.vm.box = "sle15sp1"
+            sle.vm.box = "vagrant-caasp"
             sle.vm.hostname = "caasp4-master-#{i}.#{domain}"
             sle.vm.provision "shell", inline: "hostnamectl set-hostname #{sle.vm.hostname}"
             #sle.vm.provision "shell", inline: "kubeadm config images pull"
@@ -51,7 +51,7 @@ Vagrant.configure("2") do |config|
 
     1.upto(*workercount) do |i|
         config.vm.define "caasp4-worker-#{i}" do |sle|
-            sle.vm.box = "sle15sp1"
+            sle.vm.box = "vagrant-caasp"
             sle.vm.hostname = "caasp4-worker-#{i}.#{domain}"
             sle.vm.provision "shell", inline: "hostnamectl set-hostname #{sle.vm.hostname}"
             sle.vm.provision "shell", inline: "/vagrant/boxfiles/prep_box.sh"
@@ -74,7 +74,7 @@ Vagrant.configure("2") do |config|
 
     1.upto(*lbcount) do |i|
         config.vm.define "caasp4-lb-#{i}" do |sle|
-            sle.vm.box = "sle15sp1"
+            sle.vm.box = "vagrant-caasp"
             sle.vm.hostname = "caasp4-lb-#{i}.#{domain}"
             sle.vm.provision "shell", inline: "hostnamectl set-hostname #{sle.vm.hostname}"
             sle.vm.provision "shell", inline: "/vagrant/boxfiles/prep_box.sh"
@@ -96,7 +96,7 @@ Vagrant.configure("2") do |config|
 
     1.upto(*storagecount) do |i|
         config.vm.define "caasp4-storage-#{i}" do |sle|
-            sle.vm.box = "sle15sp1"
+            sle.vm.box = "vagrant-caasp"
             sle.vm.hostname = "caasp4-storage-#{i}.#{domain}"
             sle.vm.provision "shell", inline: "hostnamectl set-hostname #{sle.vm.hostname}"
             sle.vm.provision "shell", inline: "/vagrant/boxfiles/prep_box.sh"

--- a/libvirt_setup/delete_box.sh
+++ b/libvirt_setup/delete_box.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -x
  vagrant destroy -f
- vagrant box remove sle15sp1
- sudo rm /var/lib/libvirt/images/sle15sp1_vagrant_box_image_0.img
+ vagrant box remove vagrant-caasp
+ sudo rm /var/lib/libvirt/images/vagrant-caasp_vagrant_box_image_0.img
  virsh pool-refresh default


### PR DESCRIPTION
This update adds support for CaaSP 4.5.
The box name has been changed from sle<ver>sp<sp> to simply vagrant-caasp, to be more update friendly.